### PR TITLE
Enforce axis ordering RA,DEC,FREQ,STOKES 

### DIFF
--- a/hpx_tiles/casa_tiling.py
+++ b/hpx_tiles/casa_tiling.py
@@ -17,12 +17,98 @@ import time
 import argparse
 import logging
 from casatasks import imhead, imregrid, exportfits
-
+from astropy import units as u
+from astropy_healpix import HEALPix
+from regions import Regions
+from astropy.io import fits
+from astropy import wcs
 
 logging.basicConfig(level=logging.INFO)
 
+def tileID_to_region(tileID):
+    """@Erik Osinga
+    Input; tile ID
+    Returns: Regions object (i.e. region) denoting the tile with hpx number "tileID"
+    """
+    Nside=32
+    HPX_PIXEL = tileID
+    hp = HEALPix(nside=Nside, order='ring', frame='icrs')
+    corner = hp.boundaries_lonlat(HPX_PIXEL, step=1) * u.deg
+    RA, DEC = corner.value
+    RA = RA[0]
+    DEC = DEC[0]
+    polygon_string = 'polygon(%f, %f, %f, %f, %f, %f, %f, %f)'%(RA[0], DEC[0],  RA[1], DEC[1], RA[2], DEC[2], RA[3], DEC[3])    
+    with open("regionfile.reg", 'w') as f:
+        f.write('# Region file format: DS9 astropy/regions')
+        f.write('\n')
+        f.write('fk5')
+        f.write('\n')        
+        f.write(polygon_string)
 
-def parse_args(argv):
+    r = Regions.read("regionfile.reg")
+    # clean up region file again
+    os.system("rm regionfile.reg")
+
+    return r
+
+def mask_regions(fitsimage, region, maskoutside=True):
+    """@Erik Osinga
+    Given a FITS image and a DS9 region file, mask the pixels based on the regions.
+    
+    Args:
+        fitsimage (str): Path to the FITS image file.
+        ds9region (str): Path to the DS9 region file.
+        maskoutside (bool): If True, mask everything outside the region.
+                            If False, mask everything inside the region.
+    
+    Returns:
+        np.ndarray: Masked data array, same shape as input fits image.
+    """
+    # Open the FITS file
+    with fits.open(fitsimage) as hdu:
+        # Read the region (assume its not a file but already a region object)
+        r = region
+        if len(r)>1:
+            raise ValueError(f"Expected one region file but found {len(r)}")
+        # Convert the region to a 2D pixel mask
+        rpix = r[0].to_pixel(wcs.WCS(hdu[0].header).celestial)
+        
+        # assumes final 2 axes are DEC,RA axis. 
+        # fits.open() reads in reverse order, so if first two fits axes are RA,DEC we're good
+        if ("RA" not in hdu[0].header['CTYPE1']) or ("DEC" not in hdu[0].header['CTYPE2']):
+            raise ValueError("Assumed first two axes are RA,DEC. But they are not.")
+
+        mask = rpix.to_mask().to_image(hdu[0].data.shape[-2:])
+
+        if mask is None:
+            # then the region is outside the image
+            # mask everything
+            if maskoutside:
+                mask = np.zeros(hdu[0].data.shape[-2:])
+            else:
+                mask = np.ones(hdu[0].data.shape[-2:])
+
+        naxes = hdu[0].header['naxis']
+
+        if maskoutside:
+            # Mask everything outside the region
+            setmaskto = 0
+        else:
+            # Mask everything inside the region
+            setmaskto = 1
+
+        if naxes == 4:
+            hdu[0].data[:, :, mask == setmaskto] = np.nan
+        elif naxes == 3:
+            hdu[0].data[:, mask == setmaskto] = np.nan
+        elif naxes == 2:
+            hdu[0].data[mask == setmaskto] = np.nan
+
+        data = hdu[0].data
+
+    return data
+
+def parse_args(argv):# 
     parser = argparse.ArgumentParser("Generate tiles for a specfic SB.")
     parser.add_argument("-i", dest="obs_id", help="Observation ID.", required=True)
     parser.add_argument("-c", dest="cube", help="Image cube.", required=True)
@@ -47,6 +133,57 @@ def parse_args(argv):
         default="PoSSUM",)
     args = parser.parse_args(argv)
     return args
+
+def create_nan_tile(original_image, template_fits, crpix1_and_2, outfile):
+    """@Erik Osinga
+    
+    Create a "tile" from an SB that's outside the tile using a template tile .fits file.
+        i.e. Creates a tile with all-NaNs with the same freq and stokes axis as the original_image.
+
+
+    original_image -- str       -- location of fits file of observation
+    template_fits  -- str       -- location of tile template fits file (i.e. correct projection and NAXIS1 and NAXIS2)
+    crpix1_and_2   -- [flt,flt] -- new value of CRPIX defining the centre of the tile
+    outfile        -- str       -- name of output file written
+
+    Simply masks the whole template tile .fits file and re-assign parameters CRPIX1 and CRPIX2
+    to those given by the user. Makes sure the other axes (freq,stokes) are the same as the original_imagae
+
+    Saves the result in a fitsfile "outfile"
+    """
+    # assumed values for CRPIX_1 (RA) CRPIX_2 (DEC)
+    crpix1, crpix2 = crpix1_and_2
+
+    with fits.open(original_image) as hdul_o:
+        with fits.open(template_fits) as hdul_t:
+            naxis_template = hdul_t[0].header['NAXIS']
+            naxis_original = hdul_o[0].header["NAXIS"]
+            
+            if naxis_original != naxis_template:
+                raise ValueError(f"Please provide template file with same naxis as input cube. Currently its {naxis_template} vs {naxis_original}")
+
+            # assumes last two axes are always RA,DEC
+            shape_o = hdul_o[0].data.shape[:-2]
+            shape_t = hdul_t[0].data.shape[2:]
+            # new tile should be same RA,DEC shape as template, but freq,stokes from original file
+            shape_new = shape_o + shape_t
+
+            # create NaN tile in correct shape
+            data_new = np.zeros(shape_new)*np.nan
+
+            # adjust header
+            hdul_t[0].header["CRPIX1"] = crpix1
+            hdul_t[0].header["CRPIX2"] = crpix2
+            for i in range(2,len(shape_new)):
+                # remember start counting at NAXIS1, so NAXIS3 is first non-angular coordinate
+                # and np.array() is inverted shape from fits header
+                # print(f"NAXIS{i+1} = {shape_new[::-1][i]}" )
+
+                hdul_t[0].header[f"NAXIS{i}"] = shape_new[::-1][i]
+                hdul_t[0].header[f"NAXIS{i}"] = shape_new[::-1][i]
+            
+            hdul_t[0].data = data_new
+            hdul_t[0].writeto(outfile, overwrite=False) # should be the first of its name
 
 
 def main(argv):
@@ -124,64 +261,84 @@ def main(argv):
         logging.info(f"Regridding tile {i+1}/{len(crpix1)}")
         one_tile_start = time.time()
 
-        try:
-            # this is how I will update the dictionary
-            template_header["csys"]["direction0"]["crpix"] = np.array([ra, dec])
+        # Update the template header dictionary from / for imregrid
+        template_header["csys"]["direction0"]["crpix"] = np.array([ra, dec])
 
-            if len(axis) == 4:
-                fourth_axis = axis[3]
-                if fourth_axis == "Frequency":
-                    number_of_frequency = fitsheader["shape"][3]
-                    template_header["shap"] = np.array(
-                        [naxis, naxis, 1, number_of_frequency])
+        output_filename = "%s_%s-%d.image" % (prefix, args.obs_id, pixel_ID[i])
+        output_name = os.path.join(write_dir, output_filename)
 
-                third_axis = axis[2]
-                if third_axis == "Frequency":
-                    number_of_frequency = fitsheader["shape"][2]
-                    template_header["shap"] = np.array(
-                        [naxis, naxis, number_of_frequency, 1])
+        ##############
+        # below lines added by Erik to 
+        # check if there are any non-NaN pixels in the tile region 
+        r = tileID_to_region(pixel_ID[i])
+        masked_data = mask_regions(image, r, maskoutside=True)
+        # if there are only NaN pixels, we don't need to make this tile from the current observation
+        # we can simply create a tile with all-NaN in case it needs to be combined with different freqs
+        if np.isnan(masked_data).all():
+            logging.warning("WARNING: Tile is outside the observation. If this is the case for all frequencies, then the tile does not actually require this observation.")
+            # todo: check/log this somehow? It would verify the radius needed for the tile
 
-            if len(axis) == 3:
-                third_axis = axis[2]
-                if third_axis == "Frequency":
-                    number_of_frequency = fitsheader["shape"][2]
-                    template_header["shap"] = np.array(
-                        [naxis, naxis, number_of_frequency])
-                else:
-                    template_header["shap"] = np.array([naxis, naxis, 1])
+            fitsimage=output_name.split(".image")[0] + ".fits"
+            logging.info(f"Creating NaN tile {fitsimage}")
+            create_nan_tile(image, tile_template, template_header["csys"]["direction0"]["crpix"], fitsimage)
+        ##############
 
-            output_filename = "%s_%s-%d.image" % (prefix, args.obs_id, pixel_ID[i])
-            output_name = os.path.join(write_dir, output_filename)
+        else: # if there are finite value pixels, proceed as before
 
-            # tiling, outputs tile fits in CASA image.
-            imregrid(
-                imagename=image,
-                template=template_header,
-                output=output_name,
-                axes=[0, 1],
-                interpolation="cubic",
-                overwrite=True,)
+            try:
+                if len(axis) == 4:
+                    fourth_axis = axis[3]
+                    if fourth_axis == "Frequency":
+                        number_of_frequency = fitsheader["shape"][3]
+                        template_header["shap"] = np.array(
+                            [naxis, naxis, 1, number_of_frequency])
 
-            # convert casa image to fits image
-            one_tile_end = time.time()
-            logging.info(
-                "Tiling of pixel ID %d completed. Time elapsed %.3f seconds. "
-                % (pixel_ID[i], (one_tile_end - one_tile_start)))
+                    third_axis = axis[2]
+                    if third_axis == "Frequency":
+                        number_of_frequency = fitsheader["shape"][2]
+                        template_header["shap"] = np.array(
+                            [naxis, naxis, number_of_frequency, 1])
 
-            logging.info("Converting the casa image to fits image.")
-            exportfits(
-                imagename=output_name,
-                fitsimage=output_name.split(".image")[0] + ".fits",
-                overwrite=True,
-                stokeslast=False)
+                if len(axis) == 3:
+                    third_axis = axis[2]
+                    if third_axis == "Frequency":
+                        number_of_frequency = fitsheader["shape"][2]
+                        template_header["shap"] = np.array(
+                            [naxis, naxis, number_of_frequency])
+                    else:
+                        template_header["shap"] = np.array([naxis, naxis, 1])
 
-            # delete all casa image files.
-            logging.info("Deleting the casa image. ")
-            os.system("rm -rf %s" % output_name)
-        except Exception as e:
-            logging.error(f"There was an exception: {e}")
-            logging.info("Skipping pixel")
-            # TODO: need to update csv file
+
+
+                # tiling, outputs tile fits in CASA image.
+                imregrid(
+                    imagename=image,
+                    template=template_header,
+                    output=output_name,
+                    axes=[0, 1],
+                    interpolation="cubic",
+                    overwrite=True,)
+
+                # convert casa image to fits image
+                one_tile_end = time.time()
+                logging.info(
+                    "Tiling of pixel ID %d completed. Time elapsed %.3f seconds. "
+                    % (pixel_ID[i], (one_tile_end - one_tile_start)))
+
+                logging.info("Converting the casa image to fits image.")
+                exportfits(
+                    imagename=output_name,
+                    fitsimage=output_name.split(".image")[0] + ".fits",
+                    overwrite=True,
+                    stokeslast=False)
+
+                # delete all casa image files.
+                logging.info("Deleting the casa image. ")
+                os.system("rm -rf %s" % output_name)
+            except Exception as e:
+                logging.error(f"There was an exception: {e}")
+                logging.info("Skipping tile")
+                # TODO: need to update csv file
 
     end_tiling = time.time()
     logging.info(

--- a/hpx_tiles/generate_tile_pixel_map.py
+++ b/hpx_tiles/generate_tile_pixel_map.py
@@ -72,21 +72,29 @@ def points_within_circle(x0, y0, radius, num_points=4):
     num_points: is a number of sample points within a circular beam.
 
     """
-
     angle = numpy.linspace(0, 360, num_points)
     angle = numpy.deg2rad(angle)
 
-    if (len(x0) > 1) and (len(y0) > 1):
-        x_corners = []
-        y_corners = []
+    if isinstance(x0, list):
+        ra_corners = []
+        dec_corners = []
         for (x_0, y_0) in zip(x0, y0):
-            x_corners.append(radius * numpy.cos(angle) + x_0)
-            y_corners.append(radius * numpy.sin(angle) + y_0)
-    else:
-        x_corners = radius * numpy.cos(angle) + x0
-        y_corners = radius * numpy.sin(angle) + y0
 
-    return x_corners, y_corners
+            declination = radius * numpy.sin(angle) + y_0
+            dec_corners.append( declination )
+            ra_corners.append( (radius * numpy.cos(angle))/numpy.cos(numpy.deg2rad(declination)) + x_0 )
+
+    else:
+        dec_corners = radius * numpy.sin(angle) + y0
+        ra_corners =  (radius * numpy.cos(angle))/numpy.cos(numpy.deg2rad(dec_corners)) + x0
+
+    ra_corners = numpy.asarray(ra_corners)
+    dec_corners = numpy.asarray(dec_corners)
+
+    ra_corners = ra_corners.flatten()
+    dec_corners = dec_corners.flatten()
+
+    return ra_corners, dec_corners
 
 
 def get_healpix_tiles(ra_deg, dec_deg):

--- a/metadata/add_sbid_to_ser_mosaic_header.py
+++ b/metadata/add_sbid_to_ser_mosaic_header.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+"""
+This functionality is specific to the WALLABY full survey operating scheme.
+For a given source extraction region (SER), after mosaicking, we will add the SBIDs of the constituent observations
+to the header of the mosaic file. This requires a couple of SQL queries to the WALLABY database.
+"""
+
+import os
+import sys
+import asyncpg
+import asyncio
+import logging
+from argparse import ArgumentParser
+from astropy.io import fits
+from dotenv import load_dotenv
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def main(argv):
+    parser = ArgumentParser()
+    parser.add_argument('-s', dest='ser', help='Source extraction region name')
+    parser.add_argument('-f', dest='file', help='Input mosaicked image file path')
+    parser.add_argument('-e', dest='env', help='Database credentials environment file')
+    args = parser.parse_args(argv)
+    logging.info(args)
+
+    assert os.path.exists(args.file), 'File does not exist'
+    assert os.path.exists(args.env), 'Database environment file does not exist'
+
+    # Database connection
+    load_dotenv(args.env)
+    dsn = {
+        "host": os.environ["DATABASE_HOST"],
+        "database": os.environ["DATABASE_NAME"],
+        "user": os.environ["DATABASE_USER"],
+        "password": os.environ["DATABASE_PASSWORD"],
+	    "port": os.environ["DATABASE_PORT"]
+    }
+    schema = os.environ["DATABASE_SCHEMA"]
+    conn = await asyncpg.connect(dsn=None, **dsn, server_settings={'search_path': schema})
+    logging.info('Established database connection')
+    res = await conn.fetchrow('SELECT * FROM source_extraction_region WHERE name=$1', args.ser)
+    logging.info(res)
+    if res is None:
+        raise Exception('Source extraction region does not exist')
+
+    # Get SBIDs for SER
+    async with conn.transaction():
+        footprints_for_ser_query = '''
+            SELECT t."footprint_A", t."footprint_B" FROM wallaby.source_extraction_region ser
+                LEFT JOIN wallaby.source_extraction_region_tile sert ON ser.id = sert.ser_id
+                LEFT JOIN wallaby.tile t ON sert.tile_id = t.id
+            WHERE ser.name = $1
+        '''
+        obs_ids = []
+        footprints = await conn.fetch(footprints_for_ser_query, args.ser)
+        logging.info(footprints)
+        for record in footprints:
+            obs_ids.append(int(record['footprint_A']))
+            obs_ids.append(int(record['footprint_B']))
+        logging.info(obs_ids)
+
+        sbid_list = None
+        sbid_query = f'SELECT sbid FROM observation WHERE id in {tuple(obs_ids)}'
+        logging.info(sbid_query)
+        res = await conn.fetch(sbid_query)
+        logging.info(res)
+        sbid_list = ' '.join([r['sbid'].strip('ASKAP-') for r in res])
+        logging.info(sbid_list)
+
+    await conn.close()
+
+    # Update fits
+    with fits.open(args.file, mode='update') as hdu:
+        hdr = hdu[0].header
+        hdr['SBID'] = sbid_list
+    logging.info(f'Added sbids {sbid_list} to fits cube {args.file}')
+
+
+if __name__ == '__main__':
+    argv = sys.argv[1:]
+    asyncio.run(main(argv))

--- a/metadata/requirements.txt
+++ b/metadata/requirements.txt
@@ -4,3 +4,4 @@ astroquery==0.4.6
 asyncio
 asyncpg
 packaging
+python-dotenv

--- a/plots/add_plot_to_database.py
+++ b/plots/add_plot_to_database.py
@@ -65,6 +65,11 @@ async def main(argv):
     conn = await asyncpg.connect(dsn=None, **d_dsn, server_settings={'search_path': schema})
     async with conn.transaction():
         run = await conn.fetchrow('SELECT * FROM run WHERE name=$1', args.run)
+        logging.info(run)
+        if not run:
+            logging.info(f'Run with name {args.run} not found. Creating.')
+            res = await conn.execute("INSERT INTO run (name, sanity_thresholds) VALUES ($1, '{}')", args.run)
+            run = await conn.fetchrow('SELECT * FROM run WHERE name=$1', args.run)
         run_id = int(run['id'])
         logging.info(f'Inserting into run {args.run} [{run_id}]')
         res = await conn.fetchrow(query, run_id, filebytes)

--- a/plots/plot_frequency_distribution_xml.py
+++ b/plots/plot_frequency_distribution_xml.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+"""
+Plot detection x frequency distribution to help with quality checking
+Use XML files
+"""
+
+
+import os
+import sys
+import glob
+import math
+import argparse
+import logging
+import numpy as np
+from astropy.table import vstack
+from astropy.io.votable import parse
+import matplotlib.pyplot as plt
+
+logging.basicConfig(level=logging.INFO)
+
+plt.rcParams["figure.figsize"] = (40,24)
+plt.rcParams.update({"font.size": 24})
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input', help='Directory of the sofia output products', required=True)
+    parser.add_argument('-o', '--output', help='Output filename of plot', required=True)
+    parser.add_argument('-r', '--run_name', help='Title of plot produced', required=True)
+    args = parser.parse_args(argv)
+    assert os.path.exists(args.input), "Directory of sofia output products does not exist."
+
+    # Read XML
+    files = glob.glob(os.path.join(args.input, '*.xml'))
+    logging.info(files)
+    if not files:
+        logging.info('No VOtable files found')
+        return
+    detection_table = None
+    for f in files:
+        votable = parse(f)
+        table = votable.get_first_table().to_table()
+        logging.info(f'Joining {f} with {len(table)} rows')
+        if detection_table is None:
+            detection_table = table
+            continue
+        detection_table = vstack([detection_table, table])
+    logging.debug(detection_table)
+
+    f_sum = np.log10(np.array(detection_table['f_sum'].data))
+    freq = np.array(detection_table['freq'].data) / 1e9
+
+    # Create plotla
+    plt.scatter(freq, f_sum, s=25, c="red")
+    plt.xlabel("Frequency (GHz)")
+    plt.ylabel("log(Flux / Jy Hz)")
+    plt.xlim(1.31, 1.42)
+    plt.grid()
+    plt.title(str(args.run_name))
+    plt.savefig(args.output)
+    logging.info(f'Flux vs frequency plot produced at {args.output}')
+
+if __name__ == '__main__':
+    argv = sys.argv[1:]
+    main(argv)


### PR DESCRIPTION
This update should enforce an axis ordering of `RA,DEC,FREQ,STOKES` for all tiles (and NaN tiles) irrespective of the axis ordering of the input image. The input images should still have these 4 axes though.

This gets around the fact that the MFS images come in the form `RA,DEC,FREQ,STOKES` while the cubes come in the form `RA,DEC,STOKES,FREQ`. Now all output tiles will be in the consistent format with the MFS images. 